### PR TITLE
Removed need for trimIdx and fDigitsFound, resulting in less code.

### DIFF
--- a/src/CalcManager/ExpressionCommand.cpp
+++ b/src/CalcManager/ExpressionCommand.cpp
@@ -256,38 +256,30 @@ const wstring& COpndCommand::GetToken(wchar_t decimalSymbol)
     }
 
     // Remove zeros
-    bool fDigitsFound = false;
-    int trimIdx = 0;
     for (unsigned int i = 0; i < m_token.size(); i++)
     {
         if (m_token.at(i) != chZero)
         {
-            if (m_token.at(i) == decimalSymbol)
+            if (m_token.at(i) == decimalSymbol) 
             {
-                trimIdx = i - 1;
+                m_token.erase(0, i-1);
+              
             }
             else
             {
-                trimIdx = i;
+                m_token.erase(0, i);
             }
-            fDigitsFound = true;
-            break;
+            
+            if (m_fNegative) 
+            {
+                m_token.insert(0, &chNegate);
+            }
+            return m_token;
         }
     }
-
-    if (fDigitsFound)
-    {
-        m_token.erase(0, trimIdx);
-        if (m_fNegative)
-        {
-            m_token.insert(0, &chNegate);
-        }
-    }
-    else
-    {
-        m_token.clear();
-        m_token.append(&chZero);
-    }
+     m_token.clear();
+     m_token.append(&chZero);
+  
 
     return m_token;
 }


### PR DESCRIPTION
having an extra integer variable to hold onto an i or i-1 value is inefficient, for "if (m_token.at(i) != chZero)", the code under "fDigitsFound" will always run, so it makes sense to put the fDigitsFound code under the if statement, which can return from the function entirely instead of breaking.

## Fixes #.


### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

